### PR TITLE
refactor: rename ThumbnailConfigNew to ThumbnailConfig

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,27 +84,43 @@ wrapText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[
 #### `lib/types.ts`
 
 ```typescript
-interface ThumbnailPreset {
+interface ThumbnailPlatform {
   name: string
   width: number
   height: number
   aspectRatio: string
   description: string
+  category: 'video' | 'social'
 }
 
-interface BackgroundImage {
-  name: string
-  url: string
-  thumbnail?: string
+interface BackgroundConfig {
+  type: 'gradient' | 'solid' | 'none'
+  gradientId?: string      // For gradient backgrounds
+  solidColor?: string      // For solid backgrounds
+}
+
+interface TextElement {
+  id: string              // "title", "subtitle", etc.
+  content: string
+  color?: string
+  fontSize?: string
+  fontFamily?: string
+  fontWeight?: number
+}
+
+interface ImageElement {
+  id: string              // "logo", "avatar", etc.
+  url?: string
+  opacity?: number        // 0-1
+  scale?: number          // 0-200
 }
 
 interface ThumbnailConfig {
-  title: string
-  subtitle: string
-  textColor: string
-  logoOpacity: number
-  preset: ThumbnailPreset
-  background: string
+  preset: ThumbnailPlatformWithIcon
+  layoutId: string        // References LayoutDefinition.id
+  background: BackgroundConfig
+  textElements: TextElement[]
+  imageElements: ImageElement[]
 }
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,7 +407,7 @@ Both the UI and API use the same rendering pipeline for 1:1 parity:
 
 ### API Implementation
 
-The API ([api/generate.ts](api/generate.ts)) transforms URL parameters into the same `ThumbnailConfigNew` format used by the UI, then uses `LayoutRenderer` to generate images server-side with @napi-rs/canvas.
+The API ([api/generate.ts](api/generate.ts)) transforms URL parameters into the same `ThumbnailConfig` format used by the UI, then uses `LayoutRenderer` to generate images server-side with @napi-rs/canvas.
 
 ## Future Enhancements
 

--- a/api/generate.ts
+++ b/api/generate.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path'
 import { LayoutRenderer } from '../src/lib/layout-renderer.js'
 import { validateParams, generateCacheKey, type ImageGenerationParams } from '../src/lib/api-types.js'
 import { PLATFORMS, GRADIENTS, LAYOUTS } from '../src/lib/constants.js'
-import type { ThumbnailConfigNew, BackgroundConfig, TextElement, ImageElement } from '../src/lib/types.js'
+import type { ThumbnailConfig, BackgroundConfig, TextElement, ImageElement } from '../src/lib/types.js'
 
 // Register fonts for server-side rendering
 // This runs once when the serverless function cold-starts
@@ -116,8 +116,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       scale: el.scale,
     }))
 
-    // Build ThumbnailConfigNew
-    const thumbnailConfig: ThumbnailConfigNew = {
+    // Build ThumbnailConfig
+    const thumbnailConfig: ThumbnailConfig = {
       // @ts-expect-error - preset doesn't have icon field but UI requires it
       preset: preset,
       layoutId: layout.id,

--- a/src/components/CanvasPreview.tsx
+++ b/src/components/CanvasPreview.tsx
@@ -1,9 +1,9 @@
 import { useRef, useEffect, forwardRef, useImperativeHandle, useState } from 'react'
-import type { ThumbnailConfigNew, LayoutDefinition } from '../lib/types'
+import type { ThumbnailConfig, LayoutDefinition } from '../lib/types'
 import { LayoutRenderer } from '../lib/layout-renderer'
 
 interface CanvasPreviewProps {
-  config: ThumbnailConfigNew
+  config: ThumbnailConfig
   layout: LayoutDefinition
 }
 

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -4,14 +4,14 @@ import { BackgroundSelector } from './BackgroundSelector'
 import { TextElementControl } from './TextElementControl'
 import { ImageElementControl } from './ImageElementControl'
 import { LAYOUTS } from '../lib/constants'
-import type { ThumbnailPlatformWithIcon, ThumbnailConfigNew, BackgroundConfig } from '../lib/types'
+import type { ThumbnailPlatformWithIcon, ThumbnailConfig, BackgroundConfig } from '../lib/types'
 
 interface ControlPanelProps {
   selectedPreset: ThumbnailPlatformWithIcon
   onPresetChange: (preset: ThumbnailPlatformWithIcon) => void
   selectedLayoutId: string
   onLayoutChange: (layoutId: string) => void
-  config: ThumbnailConfigNew // Full config instead of individual props
+  config: ThumbnailConfig // Full config instead of individual props
   onTextElementChange: (id: string, updates: Partial<{ content: string; color: string; fontSize: string; fontWeight: number; fontFamily: string }>) => void
   onTextElementPreview?: (id: string, updates: { fontFamily?: string; color?: string; fontWeight?: number }) => void // For hover preview
   onImageElementChange: (id: string, updates: Partial<{ url: string | undefined; opacity: number; scale: number }>) => void

--- a/src/components/Examples.tsx
+++ b/src/components/Examples.tsx
@@ -1,4 +1,4 @@
-import type { ThumbnailConfigNew } from '../lib/types'
+import type { ThumbnailConfig } from '../lib/types'
 import { PLATFORMS_WITH_ICONS } from '../lib/ui-constants'
 import { EXAMPLE_THUMBNAIL_CONFIGS } from '../lib/example-configs'
 import { ConfigSection } from './ConfigSection'
@@ -7,7 +7,7 @@ import { updateUrlForExample } from '../hooks/useExampleFromUrl'
 const EXAMPLES = EXAMPLE_THUMBNAIL_CONFIGS
 
 interface ExamplesProps {
-  onSelectExample: (config: Partial<ThumbnailConfigNew>) => void
+  onSelectExample: (config: Partial<ThumbnailConfig>) => void
   onSectionExpanded?: (sectionName: string) => void
   onSectionCollapsed?: (sectionName: string) => void
 }
@@ -16,7 +16,7 @@ export function Examples({ onSelectExample, onSectionExpanded, onSectionCollapse
   const handleSelectExample = (example: typeof EXAMPLES[number]) => {
     const preset = PLATFORMS_WITH_ICONS.find(p => p.name === example.presetName) || PLATFORMS_WITH_ICONS[0]
 
-    const config: Partial<ThumbnailConfigNew> = {
+    const config: Partial<ThumbnailConfig> = {
       preset,
       layoutId: example.layoutId,
       background: example.background,

--- a/src/components/ThumbnailGenerator.tsx
+++ b/src/components/ThumbnailGenerator.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { PLATFORMS_WITH_ICONS } from '../lib/ui-constants'
 import { GRADIENTS, LAYOUTS } from '../lib/constants'
-import type { ThumbnailPlatformWithIcon, ThumbnailConfigNew } from '../lib/types'
+import type { ThumbnailPlatformWithIcon, ThumbnailConfig } from '../lib/types'
 import { CanvasPreview } from './CanvasPreview'
 import { ControlPanel } from './ControlPanel'
 import { Tooltip } from './Tooltip'
@@ -46,7 +46,7 @@ function getDefaultImageUrl(elementId: string): string | undefined {
   return undefined
 }
 
-function loadConfigFromStorage(): ThumbnailConfigNew | null {
+function loadConfigFromStorage(): ThumbnailConfig | null {
   try {
     const stored = localStorage.getItem(STORAGE_KEY)
     if (!stored) return null
@@ -59,7 +59,7 @@ function loadConfigFromStorage(): ThumbnailConfigNew | null {
         const preset = PLATFORMS_WITH_ICONS.find(p => p.name === parsed.presetName)
         if (preset) {
           parsed.preset = preset
-          return parsed as ThumbnailConfigNew
+          return parsed as ThumbnailConfig
         }
       }
       // If preset not found, return null to use defaults
@@ -75,7 +75,7 @@ function loadConfigFromStorage(): ThumbnailConfigNew | null {
   }
 }
 
-function saveConfigToStorage(config: ThumbnailConfigNew): void {
+function saveConfigToStorage(config: ThumbnailConfig): void {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({
       presetName: config.preset.name,
@@ -89,7 +89,7 @@ function saveConfigToStorage(config: ThumbnailConfigNew): void {
   }
 }
 
-function getDefaultConfig(): ThumbnailConfigNew {
+function getDefaultConfig(): ThumbnailConfig {
   const layoutId = LAYOUTS[0].id
   return {
     preset: PLATFORMS_WITH_ICONS[0],
@@ -121,7 +121,7 @@ export function ThumbnailGenerator() {
   }, [])
 
   const savedConfig = loadConfigFromStorage()
-  const [config, setConfig] = useState<ThumbnailConfigNew>(() => {
+  const [config, setConfig] = useState<ThumbnailConfig>(() => {
     const initialConfig = savedConfig || getDefaultConfig()
     const layout = LAYOUTS.find(l => l.id === initialConfig.layoutId) || LAYOUTS[0]
 
@@ -333,7 +333,7 @@ export function ThumbnailGenerator() {
   }
 
   // Handler for selecting an example configuration
-  const handleSelectExample = useCallback((exampleConfig: Partial<ThumbnailConfigNew>): void => {
+  const handleSelectExample = useCallback((exampleConfig: Partial<ThumbnailConfig>): void => {
     setConfig(prev => {
       const newLayoutId = exampleConfig.layoutId || prev.layoutId
       const newLayout = LAYOUTS.find(l => l.id === newLayoutId) || LAYOUTS[0]

--- a/src/hooks/useExampleFromUrl.ts
+++ b/src/hooks/useExampleFromUrl.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { EXAMPLE_THUMBNAIL_CONFIGS } from '../lib/example-configs'
 import { PLATFORMS_WITH_ICONS } from '../lib/ui-constants'
-import type { ThumbnailConfigNew } from '../lib/types'
+import type { ThumbnailConfig } from '../lib/types'
 
 /**
  * Extract example ID from URL path
@@ -13,9 +13,9 @@ function getExampleIdFromUrl(): string | null {
 }
 
 /**
- * Find example config by ID and transform it to ThumbnailConfigNew format
+ * Find example config by ID and transform it to ThumbnailConfig format
  */
-function getExampleConfig(exampleId: string): Partial<ThumbnailConfigNew> | null {
+function getExampleConfig(exampleId: string): Partial<ThumbnailConfig> | null {
   const example = EXAMPLE_THUMBNAIL_CONFIGS.find(e => e.id === exampleId)
   if (!example) return null
 
@@ -36,7 +36,7 @@ function getExampleConfig(exampleId: string): Partial<ThumbnailConfigNew> | null
  * @param onSelectExample - Callback to apply the example configuration
  */
 export function useExampleFromUrl(
-  onSelectExample: (config: Partial<ThumbnailConfigNew>) => void
+  onSelectExample: (config: Partial<ThumbnailConfig>) => void
 ): void {
   const hasLoadedRef = useRef(false)
 

--- a/src/lib/layout-renderer.ts
+++ b/src/lib/layout-renderer.ts
@@ -4,7 +4,7 @@ import type {
   TextLayoutElement,
   ImageLayoutElement,
   OverlayLayoutElement,
-  ThumbnailConfigNew,
+  ThumbnailConfig,
   BackgroundConfig,
 } from './types.js'
 import { GRADIENTS } from './constants.js'
@@ -37,7 +37,7 @@ export class LayoutRenderer {
   public render(
     ctx: CanvasRenderingContext2D,
     canvas: HTMLCanvasElement,
-    config: ThumbnailConfigNew,
+    config: ThumbnailConfig,
     layout: LayoutDefinition,
     loadedImages: Map<string, HTMLImageElement>
   ): void {
@@ -86,7 +86,7 @@ export class LayoutRenderer {
   private renderElement(
     ctx: CanvasRenderingContext2D,
     canvas: HTMLCanvasElement,
-    config: ThumbnailConfigNew,
+    config: ThumbnailConfig,
     element: LayoutElement,
     loadedImages: Map<string, HTMLImageElement>
   ): void {
@@ -105,7 +105,7 @@ export class LayoutRenderer {
   private renderText(
     ctx: CanvasRenderingContext2D,
     canvas: HTMLCanvasElement,
-    config: ThumbnailConfigNew,
+    config: ThumbnailConfig,
     element: TextLayoutElement
   ): void {
     // Find the text element by ID
@@ -226,7 +226,7 @@ export class LayoutRenderer {
   private renderImage(
     ctx: CanvasRenderingContext2D,
     canvas: HTMLCanvasElement,
-    config: ThumbnailConfigNew,
+    config: ThumbnailConfig,
     element: ImageLayoutElement,
     loadedImages: Map<string, HTMLImageElement>
   ): void {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,19 +34,6 @@ export interface BackgroundImage {
   thumbnail?: string
 }
 
-export interface ThumbnailConfig {
-  title: string
-  subtitle: string
-  titleColor: string
-  subtitleColor: string
-  logoOpacity: number
-  preset: ThumbnailPlatform
-  gradientId: string
-  backgroundImageUrl?: string
-  backgroundImageScale?: number
-  customLogo?: string
-}
-
 // ============================================================================
 // Layout System Types
 // ============================================================================
@@ -156,7 +143,7 @@ export interface LayoutDefinition {
   elements: LayoutElement[]
 }
 
-export interface ThumbnailConfigNew {
+export interface ThumbnailConfig {
   preset: ThumbnailPlatformWithIcon
   layoutId: string        // References LayoutDefinition.id
   background: BackgroundConfig


### PR DESCRIPTION
Remove tech debt from layout system migration:
- Delete unused legacy ThumbnailConfig interface
- Rename ThumbnailConfigNew to ThumbnailConfig across codebase
- Update ARCHITECTURE.md with current type definitions
- Update CLAUDE.md documentation reference